### PR TITLE
bugfix: process.pid inaccessible when imported

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,20 +5,19 @@ Object.defineProperty(exports, '__esModule', {
 });
 var os = require('os');
 
+var padding = 2;
 var pad = function pad(str, size) {
   return (new Array(size + 1).join('0') + str).slice(-size);
 };
 
-var padding = 2;
-var pid = pad(process.pid.toString(36), padding);
 var hostname = os.hostname().split('').reduce(function (prev, char) {
   return +prev + char.charCodeAt(0);
 }, +os.hostname().length + 36).toString(36);
 
 var hostId = pad(hostname, padding);
 
-exports['default'] = function () {
-  return pid + hostId;
+exports['default'] = function (pid) {
+  return pad(pid.toString(36), padding) + hostId;
 };
 
 module.exports = exports['default'];

--- a/index.js
+++ b/index.js
@@ -2,10 +2,9 @@
 
 const os = require('os')
 
+const padding = 2
 const pad = (str, size) => (new Array(size + 1).join('0') + str).slice(-size)
 
-const padding = 2
-const pid = pad(process.pid.toString(36), padding)
 const hostname = os.hostname()
   .split('')
   .reduce((prev, char) => +prev + char.charCodeAt(0), +os.hostname().length + 36)
@@ -13,4 +12,4 @@ const hostname = os.hostname()
 
 const hostId = pad(hostname, padding)
 
-export default () => pid + hostId
+export default pid => pad(pid.toString(36), padding) + hostId

--- a/test.js
+++ b/test.js
@@ -6,6 +6,6 @@ let test = require('tape')
 
 test('fingerprint', (t) => {
   t.plan(2)
-  t.equal(typeof fingerprint(), 'string', 'fingerprint() should return a string');
-  t.equal(fingerprint(), fingerprint(), 'fingerprints should match');
+  t.equal(typeof fingerprint(process.pid), 'string', 'fingerprint() should return a string');
+  t.equal(fingerprint(process.pid), fingerprint(process.pid), 'fingerprints should match');
 })


### PR DESCRIPTION
Accept a `pid` param when invoking `fingerprint()` instead.
